### PR TITLE
feat(app): add on last used feat on sign-in

### DIFF
--- a/components/auth/oauth/OauthProviders.vue
+++ b/components/auth/oauth/OauthProviders.vue
@@ -4,6 +4,7 @@ import { cn } from '~/lib/utils'
 import type { IAuthProvider } from '~/types'
 
 const oauthStore = useOauthStore()
+const lastUsedMethod = ref<'email' | 'google' | 'github' | null>(null)
 
 const oauth = computed(() => {
   return oauthStore?.oauth
@@ -14,13 +15,20 @@ const onSigninWith = (provider: IAuthProvider) => {
     isSigninWithOauth: true,
     provider,
   })
+  lastUsedMethod.value = provider
+  localStorage.setItem('lastUsedMethod', provider)
   window.location.href = `/api/auth/signin/${provider}`
 }
+
+onMounted(() => {
+  const stored = localStorage.getItem('lastUsedMethod')
+  if (stored) lastUsedMethod.value = stored as any
+})
 </script>
 
 <template>
   <div class="grid gap-2 overflow-hidden">
-    <div class="flex h-[42px] items-center !overflow-hidden">
+    <div class="flex h-[42px] items-center !overflow-hidden relative">
       <button
         :disabled="oauth.isSigninWithOauth"
         :class="cn(
@@ -39,6 +47,10 @@ const onSigninWith = (provider: IAuthProvider) => {
           class="size-4"
         />
         Continue with Google
+        <span
+          v-if="lastUsedMethod === 'google'"
+          class="absolute right-2 top-2 rounded px-2 py-0.5 text-xs font-semibold border bg-background"
+        >Last used</span>
       </button>
     </div>
   </div>

--- a/components/auth/signin/SigninForm.vue
+++ b/components/auth/signin/SigninForm.vue
@@ -4,11 +4,19 @@ import UniqueCodeForm from './UniqueCodeForm.vue'
 
 const email = ref('')
 const isCodeSent = ref(false)
+const lastUsedMethod = ref<'email' | 'google' | 'github' | null>(null)
 
 function onResetForm({ mail, codeSent }: { mail: string, codeSent: boolean }) {
   email.value = mail
   isCodeSent.value = codeSent
+  lastUsedMethod.value = 'email'
+  localStorage.setItem('lastUsedMethod', 'email')
 }
+
+onMounted(() => {
+  const stored = localStorage.getItem('lastUsedMethod')
+  if (stored) lastUsedMethod.value = stored as any
+})
 </script>
 
 <template>

--- a/components/auth/signin/UniqueCodeForm.vue
+++ b/components/auth/signin/UniqueCodeForm.vue
@@ -70,7 +70,7 @@ const onSendUniqueCode = sendUniqueCodeForm.handleSubmit(async (values) => {
     @submit.prevent="onSendUniqueCode"
   >
     <div
-      v-if="lastUsedMethod === 'email'"
+      v-if="props.lastUsedMethod === 'email'"
       class="mb-2 flex items-center justify-end"
     >
       <span class="rounded px-2 py-0.5 text-xs font-semibold border bg-background">Last used</span>

--- a/components/auth/signin/UniqueCodeForm.vue
+++ b/components/auth/signin/UniqueCodeForm.vue
@@ -69,6 +69,12 @@ const onSendUniqueCode = sendUniqueCodeForm.handleSubmit(async (values) => {
     class="mt-5 space-y-4"
     @submit.prevent="onSendUniqueCode"
   >
+    <div
+      v-if="lastUsedMethod === 'email'"
+      class="mb-2 flex items-center justify-end"
+    >
+      <span class="rounded px-2 py-0.5 text-xs font-semibold border bg-background">Last used</span>
+    </div>
     <FormField
       v-slot="{ componentField }"
       name="email"


### PR DESCRIPTION
This pull request enhances the authentication UI by introducing a "Last used" indicator for sign-in methods and persisting the user's last chosen method across sessions. The changes improve user experience by making it easier for users to identify and reuse their preferred authentication method.

**User experience improvements:**

* Added a `lastUsedMethod` state to both `OauthProviders.vue` and `SigninForm.vue` to track the last sign-in method used by the user. This state is persisted in `localStorage` and restored on component mount. [[1]](diffhunk://#diff-fdad5c84cc37bdff7259609174feb6315eb58c215487b3a6a1776b8cf5e3209eR7) [[2]](diffhunk://#diff-fcb32aa3a0f0326f643bf76aed11ca82939a4d5f98d46505116102deb97b0b55R7-R19)
* Updated the OAuth sign-in flow to store the selected provider in `lastUsedMethod` and `localStorage` when a user initiates sign-in.
* Added a "Last used" badge to the Google OAuth button in `OauthProviders.vue` when it was the most recent sign-in method.
* Updated the email sign-in form to store "email" as the last used method and display a "Last used" badge when appropriate. [[1]](diffhunk://#diff-fcb32aa3a0f0326f643bf76aed11ca82939a4d5f98d46505116102deb97b0b55R7-R19) [[2]](diffhunk://#diff-c76a6d26b3461a105ad1f51d2487df2dc1b0c8498bef246a3fb8fdf40234b580R72-R77)